### PR TITLE
Fix/localtime dataformat

### DIFF
--- a/src/main/java/com/sparta/taskflow/global/config/JacksonConfig.java
+++ b/src/main/java/com/sparta/taskflow/global/config/JacksonConfig.java
@@ -1,0 +1,23 @@
+package com.sparta.taskflow.global.config;
+
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class JacksonConfig {
+
+    private static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    private static final LocalDateTimeSerializer LOCAL_DATE_TIME_SERIALIZER =
+            new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATETIME_FORMAT));
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+        return builder -> builder.serializers(LOCAL_DATE_TIME_SERIALIZER);
+    }
+}
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ server:
 
 spring:
   jackson:
-    time-zone: Asia/Seoul
-    date-format: yyyy-MM-dd HH:mm:ss
+    time-zone: UTC
+    date-format: com.fasterxml.jackson.databind.util.StdDateFormat
   datasource:
     # 데이터베이스 연결 URL (로컬 MySQL 기준)
     url: jdbc:mysql://localhost:3306/taskflow?serverTimezone=Asia/Seoul

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ server:
 
 spring:
   jackson:
-    time-zone: UTC
-    date-format: com.fasterxml.jackson.databind.util.StdDateFormat
+    time-zone: Asia/Seoul
+    date-format: yyyy-MM-dd HH:mm:ss
   datasource:
     # 데이터베이스 연결 URL (로컬 MySQL 기준)
     url: jdbc:mysql://localhost:3306/taskflow?serverTimezone=Asia/Seoul

--- a/src/test/java/com/sparta/taskflow/TaskflowApplicationTests.java
+++ b/src/test/java/com/sparta/taskflow/TaskflowApplicationTests.java
@@ -8,6 +8,7 @@ class TaskflowApplicationTests {
 
     @Test
     void contextLoads() {
+
     }
 
 }

--- a/src/test/java/com/sparta/taskflow/timeformat/LocalTimeFormatTest.java
+++ b/src/test/java/com/sparta/taskflow/timeformat/LocalTimeFormatTest.java
@@ -1,0 +1,42 @@
+package com.sparta.taskflow.timeformat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest
+@AutoConfigureJsonTesters
+public class LocalTimeFormatTest {
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Test
+    void localDateTime직렬화확인() throws Exception {
+        // given
+        SampleDto dto = new SampleDto(LocalDateTime.now());
+        
+        // when
+        String json = objectMapper.writeValueAsString(dto);
+        
+        //then
+        System.out.println("json = " + json);
+    }
+    
+    static class SampleDto{
+        private final LocalDateTime localDateTime;
+        
+        public SampleDto(LocalDateTime localDateTime) {
+            this.localDateTime = localDateTime;
+        }
+
+        public LocalDateTime getLocalDateTime() {
+            return localDateTime;
+        }
+    }
+    
+}


### PR DESCRIPTION
## 이슈 번호
#1 

## 작업 내용
    - Jackson ObjectMapper에 LocalDateTimeSerializer 등록
    - 'yyyy-MM-dd'T'HH:mm:ss'Z'' 형식으로 직렬화되도록 커스터마이징
    - 서버 응답에서 날짜/시간 포맷을 ISO 8601 형식으로 통일
    - Test코드로 확인