### PR TITLE
feat: 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/sparta/taskflow/auth/annotation/ValidPasswordPattern.java
+++ b/src/main/java/com/sparta/taskflow/auth/annotation/ValidPasswordPattern.java
@@ -1,0 +1,27 @@
+package com.sparta.taskflow.auth.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Pattern(
+    regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$",
+    message = "비밀번호 형식이 올바르지 않습니다. 8자 이상, 대소문자 포함, 숫자 및 특수문자(@$!%*?&#) 포함"
+)
+@Constraint(validatedBy = {})
+public @interface ValidPasswordPattern {
+
+    String message()
+        default "비밀번호 형식이 올바르지 않습니다. 8자 이상, 대소문자 포함, 숫자 및 특수문자(@$!%*?&#) 포함";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.sparta.taskflow.auth.controller;
+
+import com.sparta.taskflow.auth.service.AuthService;
+import com.sparta.taskflow.auth.dto.request.RegisterRequestDto;
+import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
+import com.sparta.taskflow.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<UserResponseDto>> register(
+        @Valid @RequestBody RegisterRequestDto requestDto) {
+        UserResponseDto responseDto = authService.register(requestDto);
+
+        ApiResponse<UserResponseDto> response = ApiResponse.success("회원가입이 완료되었습니다.", responseDto);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/sparta/taskflow/auth/dto/request/RegisterRequestDto.java
+++ b/src/main/java/com/sparta/taskflow/auth/dto/request/RegisterRequestDto.java
@@ -1,0 +1,26 @@
+package com.sparta.taskflow.auth.dto.request;
+
+import com.sparta.taskflow.auth.annotation.ValidPasswordPattern;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class RegisterRequestDto {
+
+    @Pattern(regexp = "^[a-zA-Z0-9]{4,20}$", message = "4-20자의 영문과 숫자를 입력하세요.")
+    private String username;
+
+    @Email
+    @NotNull
+    private String email;
+
+    @ValidPasswordPattern
+    private String password;
+
+    @Size(min = 2, max = 50)
+    @NotNull
+    private String name;
+}

--- a/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
@@ -1,0 +1,48 @@
+package com.sparta.taskflow.auth.service;
+
+import com.sparta.taskflow.auth.dto.request.RegisterRequestDto;
+import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
+import com.sparta.taskflow.domain.user.entity.User;
+import com.sparta.taskflow.domain.user.repository.UserRepository;
+import com.sparta.taskflow.domain.user.type.RoleType;
+import com.sparta.taskflow.global.exception.CustomException;
+import com.sparta.taskflow.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserResponseDto register(RegisterRequestDto requestDto) {
+        checkDuplicatesOrThrow(requestDto.getUsername(), requestDto.getEmail());
+
+        User user = User.builder().username(requestDto.getUsername()).email(requestDto.getEmail())
+                        .password(passwordEncoder.encode(requestDto.getPassword()))
+                        .name(requestDto.getName())
+                        .role(RoleType.USER) // Todo: Role이 요청에 없는데 응답에는 있다
+                        .isDeleted(false).build();
+
+        User savedUser = userRepository.save(user);
+
+        return UserResponseDto.of(savedUser);
+    }
+
+    private void checkDuplicatesOrThrow(String username, String email) {
+        // username 중복 확인
+        boolean hasDuplicateUsername = userRepository.existsByUsername(username);
+        if (hasDuplicateUsername) {
+            throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
+        }
+
+        // email 중복 확인
+        boolean hasDuplicateEmail = userRepository.existsByEmail(email);
+        if (hasDuplicateEmail) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+}

--- a/src/main/java/com/sparta/taskflow/domain/user/dto/UserSummaryDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/dto/UserSummaryDto.java
@@ -1,0 +1,11 @@
+package com.sparta.taskflow.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public class UserSummaryDto {
+
+    private Long id;
+    private String username;
+    private String name;
+}

--- a/src/main/java/com/sparta/taskflow/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/dto/response/UserResponseDto.java
@@ -1,0 +1,29 @@
+package com.sparta.taskflow.domain.user.dto.response;
+
+import com.sparta.taskflow.domain.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UserResponseDto {
+
+    private Long id;
+    private String username;
+    private String email;
+    private String name;
+    private String role;
+    private LocalDateTime createdAt;
+
+    public static UserResponseDto of(User user) {
+        return UserResponseDto.builder()
+                              .id(user.getId())
+                              .username(user.getUsername())
+                              .email(user.getEmail())
+                              .name(user.getName())
+                              .role(user.getRole().getValue())
+                              .createdAt(user.getCreatedAt())
+                              .build();
+    }
+}

--- a/src/main/java/com/sparta/taskflow/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/entity/User.java
@@ -1,0 +1,42 @@
+package com.sparta.taskflow.domain.user.entity;
+
+import com.sparta.taskflow.domain.user.type.RoleType;
+import com.sparta.taskflow.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String username;
+    private String email;
+    private String password;
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType role;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.taskflow.domain.user.repository;
+
+import com.sparta.taskflow.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+
+}

--- a/src/main/java/com/sparta/taskflow/domain/user/type/RoleType.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/type/RoleType.java
@@ -1,0 +1,23 @@
+package com.sparta.taskflow.domain.user.type;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum RoleType {
+    ADMIN("ADMIN"),
+    USER("USER");
+
+    private final String value;
+
+    RoleType(String value) {
+        this.value = value;
+    }
+
+    public static RoleType from(String role) {
+        return Arrays.stream(values())
+                     .filter(roleType -> roleType.value.equals(role))
+                     .findFirst()
+                     .orElseThrow(() -> new IllegalArgumentException("Invalid role: " + role));
+    }
+}

--- a/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.sparta.taskflow.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable).formLogin(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> {
+                auth.requestMatchers("/**").permitAll(); // 아직 인증 안 함
+            });
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
@@ -4,9 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 /**
- * 모든 예외 상황을 Enum으로 구성하여
- * HTTP 상태코드와 에러 내용을
- * 명확하게 정의한다
+ * 모든 예외 상황을 Enum으로 구성하여 HTTP 상태코드와 에러 내용을 명확하게 정의한다
  */
 @Getter
 public enum ErrorCode {
@@ -20,7 +18,8 @@ public enum ErrorCode {
 
     // User 관련 에러 정의
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중 인 사용자 이름입니다");
+    DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자명입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
 
     // 필드
     // HTTP 상태코드

--- a/src/main/java/com/sparta/taskflow/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/GlobalExceptionHandler.java
@@ -25,12 +25,13 @@ public class GlobalExceptionHandler {
         log.warn("[클라이언트 예외 발생] {} - {}", errorCode.name(), errorCode.getMessage());
 
         return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorResponseDto.getMessage(), errorResponseDto));
+            .status(errorCode.getStatus())
+            .body(ApiResponse.fail(errorResponseDto.getMessage(), errorResponseDto));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<ErrorResponseDto>> handleValidationException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<ErrorResponseDto>> handleValidationException(
+        MethodArgumentNotValidException e) {
 
         ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
         String message;
@@ -45,13 +46,13 @@ public class GlobalExceptionHandler {
         log.warn("[벨리데이션 예외 발생] {} - {}", errorCode.name(), message);
 
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(
-                errorCode.getStatus().value(),
-                errorCode.name(),
-                message);
+            errorCode.getStatus().value(),
+            errorCode.name(),
+            message);
 
         return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.fail(errorResponseDto.getMessage(), errorResponseDto));
+            .status(errorCode.getStatus())
+            .body(ApiResponse.fail(errorResponseDto.getMessage(), errorResponseDto));
     }
 
     // 예상하지 못한 예외 처리
@@ -64,7 +65,7 @@ public class GlobalExceptionHandler {
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(unexpectedError);
 
         return ResponseEntity
-                .status(unexpectedError.getStatus())
-                .body(ApiResponse.fail(errorResponseDto.getMessage(), errorResponseDto));
+            .status(unexpectedError.getStatus())
+            .body(ApiResponse.fail(errorResponseDto.getMessage(), errorResponseDto));
     }
 }

--- a/src/test/java/com/sparta/taskflow/auth/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/sparta/taskflow/auth/AuthServiceIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.sparta.taskflow.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.sparta.taskflow.auth.dto.request.RegisterRequestDto;
+import com.sparta.taskflow.auth.service.AuthService;
+import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
+import com.sparta.taskflow.global.exception.CustomException;
+import com.sparta.taskflow.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest // Mockito 의존성 없어 일단 SpringBootTest 사용
+@Transactional
+@ActiveProfiles("test")
+class AuthServiceIntegrationTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Test
+    void 정상_회원가입() {
+        // given
+        RegisterRequestDto requestDto = getRegisterRequestDto("user@email.com", "username");
+
+        // when
+        UserResponseDto responseDto = authService.register(requestDto);
+
+        // then
+        assertThat(responseDto.getId()).isNotNull();
+    }
+
+    @Test
+    void 회원가입_이메일_중복() {
+        // given
+        RegisterRequestDto request1 = getRegisterRequestDto("user@email.com", "username1");
+        RegisterRequestDto duplicateEmailRequest = getRegisterRequestDto("user@email.com",
+            "username2");
+
+        // when
+        authService.register(request1);
+        Throwable thrown = catchThrowable(() -> authService.register(duplicateEmailRequest));
+
+        // then
+        assertThat(thrown)
+            .isInstanceOf(CustomException.class);
+        CustomException exception = (CustomException) thrown;
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+    }
+
+    @Test
+    void 회원가입_유저네임_중복() {
+        // given
+        RegisterRequestDto request1 = getRegisterRequestDto("user@email.com", "username1");
+        RegisterRequestDto duplicateUsernameRequest = getRegisterRequestDto("user2@email.com",
+            "username1");
+
+        // when
+        authService.register(request1);
+        Throwable thrown = catchThrowable(() -> authService.register(duplicateUsernameRequest));
+
+        // then
+        assertThat(thrown)
+            .isInstanceOf(CustomException.class);
+        CustomException exception = (CustomException) thrown;
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_USERNAME);
+    }
+
+    private static RegisterRequestDto getRegisterRequestDto(String email, String username) {
+        RegisterRequestDto requestDto = new RegisterRequestDto();
+        ReflectionTestUtils.setField(requestDto, "email", email);
+        ReflectionTestUtils.setField(requestDto, "username", username);
+        ReflectionTestUtils.setField(requestDto, "password", "password");
+        ReflectionTestUtils.setField(requestDto, "name", "name");
+        return requestDto;
+    }
+}


### PR DESCRIPTION
## 이슈 번호
#14

## 작업 내용
- User 엔티티, UserRepository, UserResponseDto, RoleType enum 정의
- 회원가입 구현: AuthController, AuthService, RegisterRequestDto
- 비밀번호 패턴에 auth 하위 별도 ValidPasswordPattern 어노테이션 정의
- SecurityConfig 설정: 모든 url 개방, PasswordEncoder로 Spring Security 기본 DelegatingPasswordEncoder 사용 (기본값 bcrypt)
- ErrorCode 변경 및 추가: DUPLICATE_USERNAME BAD_REQUEST로 변경, DUPLICATE_EMAIL 추가 정의
- 테스트코드 작성: AuthServiceIntegrationTest 내부에 회원가입 메소드에 대한 테스트코드 작성, profile을 test로 설정하고 환경변수 정의해야 제대로 동작

- UserSummaryDto 정의

## 스크린샷(선택)

## 비고
- User 엔티티의 email도 unique 제약 조건 걸어야 함
- 현재 회원가입 요청에 Role이 들어오고 있지 않아 모든 회원가입은 RoleType을 USER로 설정