### PR TITLE
feature/searchComment

### DIFF
--- a/src/main/java/com/sparta/taskflow/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/controller/CommentController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,5 +42,13 @@ public class CommentController {
     ) {
         List<CreateCommentResponseDto> responseDtoList = commentService.getCommentsByTask(taskId);
         return ResponseEntity.ok(ApiResponse.success("댓글을 조회했습니다.", responseDtoList));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<CreateCommentResponseDto>>> searchComments(
+        @RequestParam("keyword") String keyword
+    ) {
+        List<CreateCommentResponseDto> result = commentService.searchComments(keyword);
+        return ResponseEntity.ok(ApiResponse.success("댓글 검색 결과입니다.", result));
     }
 }

--- a/src/main/java/com/sparta/taskflow/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/controller/CommentController.java
@@ -5,8 +5,11 @@ import com.sparta.taskflow.domain.comment.dto.CreateCommentResponseDto;
 import com.sparta.taskflow.domain.comment.service.CommentService;
 import com.sparta.taskflow.response.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +33,13 @@ public class CommentController {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/task/{taskId}")
+    public ResponseEntity<ApiResponse<List<CreateCommentResponseDto>>> getCommentsByTask(
+        @PathVariable Long taskId
+    ) {
+        List<CreateCommentResponseDto> responseDtoList = commentService.getCommentsByTask(taskId);
+        return ResponseEntity.ok(ApiResponse.success("댓글을 조회했습니다.", responseDtoList));
     }
 }

--- a/src/main/java/com/sparta/taskflow/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/repository/CommentRepository.java
@@ -1,10 +1,12 @@
 package com.sparta.taskflow.domain.comment.repository;
 
 import com.sparta.taskflow.domain.comment.entity.Comment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    List<Comment> findAllByTaskIdAndIsDeletedFalseOrderByCreatedAtDesc(Long taskId);
 }

--- a/src/main/java/com/sparta/taskflow/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/repository/CommentRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    List<Comment> findAllByTaskIdAndIsDeletedFalseOrderByCreatedAtDesc(Long taskId);
+    List<Comment> findAllByTaskIdAndIsDeletedFalseOrderByCreatedAtDesc(Long taskId); // 조회
+
+    List<Comment> findAllByContentContainingIgnoreCaseAndIsDeletedFalseOrderByCreatedAtDesc(String keyword); // 검색
 }

--- a/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
@@ -4,6 +4,8 @@ import com.sparta.taskflow.domain.comment.dto.CreateCommentRequestDto;
 import com.sparta.taskflow.domain.comment.dto.CreateCommentResponseDto;
 import com.sparta.taskflow.domain.comment.entity.Comment;
 import com.sparta.taskflow.domain.comment.repository.CommentRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,4 +26,11 @@ public class CommentService {
         return CreateCommentResponseDto.of(saved);
     }
 
+    public List<CreateCommentResponseDto> getCommentsByTask(Long taskId) {
+        List<Comment> comments = commentRepository.findAllByTaskIdAndIsDeletedFalseOrderByCreatedAtDesc(
+            taskId);
+        return comments.stream()
+                       .map(CreateCommentResponseDto::of)
+                       .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
@@ -33,4 +33,13 @@ public class CommentService {
                        .map(CreateCommentResponseDto::of)
                        .collect(Collectors.toList());
     }
+
+    public List<CreateCommentResponseDto> searchComments(String keyword) {
+        List<Comment> comments = commentRepository
+            .findAllByContentContainingIgnoreCaseAndIsDeletedFalseOrderByCreatedAtDesc(keyword);
+
+        return comments.stream()
+                       .map(CreateCommentResponseDto::of)
+                       .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 이슈 번호
#21

## 작업 내용
- 댓글 본문 내용에 대해 Like 검색 쿼리 작성
- soft delete 된 댓글 제외
- 최신순 정렬
- `/api/comments/search?keyword=` 형태의 GET API 추가
- 응답 포맷은 CreateCommentResponseDto 재사용

## 스크린샷(선택)
