### PR TITLE
Feat : delete user

### DIFF
--- a/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
@@ -2,7 +2,9 @@ package com.sparta.taskflow.auth.controller;
 
 import com.sparta.taskflow.auth.service.AuthService;
 import com.sparta.taskflow.auth.dto.request.RegisterRequestDto;
+import com.sparta.taskflow.domain.user.dto.request.DeleteUserRequestDto;
 import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
+import com.sparta.taskflow.domain.user.service.UserService;
 import com.sparta.taskflow.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final UserService userService;
 
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<UserResponseDto>> register(
@@ -26,6 +30,17 @@ public class AuthController {
 
         ApiResponse<UserResponseDto> response = ApiResponse.success("회원가입이 완료되었습니다.", responseDto);
 
+        return ResponseEntity.ok(response);
+    }
+
+    // TODO : SpringSecurity 적용 이후 로그인 유저 정보 받는 방법으로 변경 필요.
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+        @RequestParam Long loginUserId,
+        @RequestBody @Valid DeleteUserRequestDto deleteUserDto
+    ) {
+        userService.deleteUser(loginUserId, deleteUserDto);
+        ApiResponse<Void> response = ApiResponse.success("회원탈퇴가 완료되었습니다.", null);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/sparta/taskflow/domain/task/dto/response/CreateTaskResponseDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/task/dto/response/CreateTaskResponseDto.java
@@ -5,10 +5,9 @@ import com.sparta.taskflow.domain.task.type.PriorityType;
 import com.sparta.taskflow.domain.task.type.StatusType;
 import com.sparta.taskflow.domain.user.dto.UserSummaryDto;
 import com.sparta.taskflow.domain.user.entity.User;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -33,13 +32,8 @@ public class CreateTaskResponseDto {
                                     .description(task.getDescription())
                                     .priority(task.getPriority())
                                     .status(task.getStatus())
-                                    .assigneeId(assignee.getId())
-                                    .assignee(UserSummaryDto.builder()
-                                                            .id(assignee.getId())
-                                                            .username(assignee.getUsername())
-                                                            .name(assignee.getName())
-                                                            .email(assignee.getEmail())
-                                                            .build())
+                                    .assigneeId(assignee != null ? assignee.getId() : null)
+                                    .assignee(assignee != null ? UserSummaryDto.of(assignee) : new UserSummaryDto())
                                     .dueDate(task.getDueDate())
                                     .createdAt(task.getCreatedAt())
                                     .updatedAt(task.getUpdatedAt())

--- a/src/main/java/com/sparta/taskflow/domain/task/dto/response/TaskResponseDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/task/dto/response/TaskResponseDto.java
@@ -4,18 +4,19 @@ import com.sparta.taskflow.domain.task.entity.Task;
 import com.sparta.taskflow.domain.task.type.PriorityType;
 import com.sparta.taskflow.domain.task.type.StatusType;
 import com.sparta.taskflow.domain.user.dto.UserSummaryDto;
-import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
+import com.sparta.taskflow.domain.user.entity.User;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class TaskResponseDto {
+
     private Long id;
     private String title;
     private String description;
@@ -28,19 +29,15 @@ public class TaskResponseDto {
     private LocalDateTime updatedAt;
 
     public static TaskResponseDto of(Task task) {
+        User assignee = task.getAssignee();
         return TaskResponseDto.builder()
                               .id(task.getId())
                               .title(task.getTitle())
                               .description(task.getDescription())
                               .priority(task.getPriority())
                               .status(task.getStatus())
-                              .assigneeId(task.getAssignee().getId())
-                              .assignee(UserSummaryDto.builder()
-                                                      .id(task.getAssignee().getId())
-                                                      .username(task.getAssignee().getUsername())
-                                                      .name(task.getAssignee().getName())
-                                                      .email(task.getAssignee().getEmail())
-                                                      .build())
+                              .assigneeId(assignee != null ? assignee.getId() : null)
+                              .assignee(assignee != null ? UserSummaryDto.of(assignee) : new UserSummaryDto())
                               .dueDate(task.getDueDate())
                               .createdAt(task.getCreatedAt())
                               .updatedAt(task.getUpdatedAt())

--- a/src/main/java/com/sparta/taskflow/domain/task/entity/Task.java
+++ b/src/main/java/com/sparta/taskflow/domain/task/entity/Task.java
@@ -4,13 +4,21 @@ import com.sparta.taskflow.domain.task.type.PriorityType;
 import com.sparta.taskflow.domain.task.type.StatusType;
 import com.sparta.taskflow.domain.user.entity.User;
 import com.sparta.taskflow.global.entity.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -36,7 +44,7 @@ public class Task extends BaseTimeEntity {
     private StatusType status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "assignee_id", nullable = false)
+    @JoinColumn(name = "assignee_id")
     private User assignee;
 
     @Column(name = "start_date")
@@ -51,7 +59,8 @@ public class Task extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void update(String title, String description, LocalDateTime dueDate, PriorityType priority, StatusType status, User assignee) {
+    public void update(String title, String description, LocalDateTime dueDate, PriorityType priority,
+        StatusType status, User assignee) {
 
         this.title = title;
         this.description = description;

--- a/src/main/java/com/sparta/taskflow/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/task/repository/TaskRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -30,5 +31,9 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     );
 
     Optional<Task> findByIdAndIsDeletedFalse(Long id);
+
+    @Modifying
+    @Query("UPDATE Task t SET t.assignee.id = null WHERE t.assignee.id = :userId")
+    void unassignTasksByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/sparta/taskflow/domain/task/service/TaskService.java
+++ b/src/main/java/com/sparta/taskflow/domain/task/service/TaskService.java
@@ -8,22 +8,17 @@ import com.sparta.taskflow.domain.task.dto.response.TaskResponseDto;
 import com.sparta.taskflow.domain.task.entity.Task;
 import com.sparta.taskflow.domain.task.repository.TaskRepository;
 import com.sparta.taskflow.domain.task.type.StatusType;
-import com.sparta.taskflow.domain.user.dto.UserSummaryDto;
-import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
 import com.sparta.taskflow.domain.user.entity.User;
 import com.sparta.taskflow.domain.user.repository.UserRepository;
 import com.sparta.taskflow.global.exception.CustomException;
 import com.sparta.taskflow.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -36,9 +31,13 @@ public class TaskService {
     @Transactional
     public CreateTaskResponseDto createTask(CreateTaskRequestDto requestDto) {
 
-        User assignee = userRepository.findById(requestDto.getAssigneeId())
-                                      .filter(user -> !user.isDeleted())
-                                      .orElseThrow(() ->  new CustomException(ErrorCode.ASSIGNEE_NOT_FOUND));
+        User assignee = null;
+
+        if (requestDto.getAssigneeId() != null) {
+            assignee = userRepository.findById(requestDto.getAssigneeId())
+                                     .filter(user -> !user.isDeleted())
+                                     .orElseThrow(() -> new CustomException(ErrorCode.ASSIGNEE_NOT_FOUND));
+        }
 
         Task task = Task.builder()
                         .title(requestDto.getTitle())

--- a/src/main/java/com/sparta/taskflow/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/controller/UserController.java
@@ -29,14 +29,4 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("사용자 정보를 조회했습니다.", response));
     }
 
-    // TODO : SpringSecurity 적용 이후 로그인 유저 정보 받는 방법으로 변경 필요.
-    @PostMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Void>> withdraw(
-        @RequestParam Long loginUserId,
-        @RequestBody @Valid DeleteUserRequestDto deleteUserDto
-    ) {
-        userService.deleteUser(loginUserId, deleteUserDto);
-        ApiResponse<Void> response = ApiResponse.success("회원탈퇴가 완료되었습니다.", null);
-        return ResponseEntity.ok(response);
-    }
 }

--- a/src/main/java/com/sparta/taskflow/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/controller/UserController.java
@@ -1,11 +1,15 @@
 package com.sparta.taskflow.domain.user.controller;
 
+import com.sparta.taskflow.domain.user.dto.request.DeleteUserRequestDto;
 import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
 import com.sparta.taskflow.domain.user.service.UserService;
 import com.sparta.taskflow.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,9 +22,21 @@ public class UserController {
     private final UserService userService;
 
     // TODO : SpringSecurity 적용 이후 로그인 유저 정보 받는 방법으로 변경 필요.
+    // TODO : 조회 시 isDeleted = false인 유저만 조회하도록 변경
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserResponseDto>> getUserByLoginUser(@RequestParam Long loginUserId) {
         UserResponseDto response = userService.getUser(loginUserId);
         return ResponseEntity.ok(ApiResponse.success("사용자 정보를 조회했습니다.", response));
+    }
+
+    // TODO : SpringSecurity 적용 이후 로그인 유저 정보 받는 방법으로 변경 필요.
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+        @RequestParam Long loginUserId,
+        @RequestBody @Valid DeleteUserRequestDto deleteUserDto
+    ) {
+        userService.deleteUser(loginUserId, deleteUserDto);
+        ApiResponse<Void> response = ApiResponse.success("회원탈퇴가 완료되었습니다.", null);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/sparta/taskflow/domain/user/dto/UserSummaryDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/dto/UserSummaryDto.java
@@ -1,15 +1,29 @@
 package com.sparta.taskflow.domain.user.dto;
 
+import com.sparta.taskflow.domain.user.entity.User;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserSummaryDto {
 
     private Long id;
     private String username;
     private String name;
     private String email;
+
+    public static UserSummaryDto of(User user) {
+        return UserSummaryDto.builder()
+                             .id(user.getId())
+                             .username(user.getUsername())
+                             .name(user.getName())
+                             .email(user.getEmail())
+                             .build();
+    }
 
 }

--- a/src/main/java/com/sparta/taskflow/domain/user/dto/request/DeleteUserRequestDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/dto/request/DeleteUserRequestDto.java
@@ -1,0 +1,11 @@
+package com.sparta.taskflow.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DeleteUserRequestDto {
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/sparta/taskflow/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/entity/User.java
@@ -14,13 +14,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE user SET is_deleted = true, deleted_at = NOW() WHERE id = ?")
 public class User extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/sparta/taskflow/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/service/UserService.java
@@ -1,8 +1,14 @@
 package com.sparta.taskflow.domain.user.service;
 
+import com.sparta.taskflow.domain.task.repository.TaskRepository;
+import com.sparta.taskflow.domain.user.dto.request.DeleteUserRequestDto;
 import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
 import com.sparta.taskflow.domain.user.entity.User;
 import com.sparta.taskflow.domain.user.repository.UserRepository;
+import com.sparta.taskflow.global.exception.CustomException;
+import com.sparta.taskflow.global.exception.ErrorCode;
+import com.sparta.taskflow.global.validator.PasswordValidator;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,9 +17,25 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final TaskRepository taskRepository;
+    private final PasswordValidator passwordValidator;
 
     public UserResponseDto getUser(Long loginUserId) {
         User foundUser = userRepository.findByIdOrElseThrow(loginUserId);
         return UserResponseDto.of(foundUser);
+    }
+
+    @Transactional
+    public void deleteUser(Long loginUserId, DeleteUserRequestDto deleteUserDto) {
+        User user = userRepository.findByIdAndIsDeletedFalse(loginUserId).orElseThrow(
+            () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        passwordValidator.verifyMatch(deleteUserDto.getPassword(), user.getPassword());
+
+        userRepository.deleteById(user.getId());
+
+        // Task 미할당 상태로 변경
+        taskRepository.unassignTasksByUserId(user.getId());
     }
 }

--- a/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자명입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
     // Task 관련 에러 정의
     ASSIGNEE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않거나 탈퇴된 담당자입니다."),

--- a/src/main/java/com/sparta/taskflow/global/validator/PasswordValidator.java
+++ b/src/main/java/com/sparta/taskflow/global/validator/PasswordValidator.java
@@ -1,0 +1,27 @@
+package com.sparta.taskflow.global.validator;
+
+import com.sparta.taskflow.global.exception.CustomException;
+import com.sparta.taskflow.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordValidator {
+
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 입력받은 비밀번호와 기존의 비밀번호의 일치여부에 따른 예외 처리
+     *
+     * @param inputPassword    입력받은 비밀번호
+     * @param originalPassword 기존의 비밀번호
+     */
+    public void verifyMatch(String inputPassword, String originalPassword) {
+        if (!passwordEncoder.matches(inputPassword, originalPassword)) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+}


### PR DESCRIPTION
## 이슈 번호
#25

## 작업 내용
- Task 생성 시 assignee가 null이 저장되도록 변경
- assignee가 null일때에도 Dto에 매핑할 수 있도록 매핑 로직 수정

- password일치 검증을 위한 클래스 PasswordValidator 생성
- 비밀번호 불일치 시 발생하는 ErrorCode 추가
- DeleteUserRequestDto 추가
- @SQLDelete 어노테이션 설정
- UserSummaryDto of() 추가

## 스크린샷(선택)
