### PR TITLE
feat: 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // JWT 관련 의존성
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.mockito:mockito-core:5.18.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.sparta.taskflow.auth.controller;
 
-import com.sparta.taskflow.auth.service.AuthService;
+import com.sparta.taskflow.auth.dto.request.LoginRequestDto;
 import com.sparta.taskflow.auth.dto.request.RegisterRequestDto;
+import com.sparta.taskflow.auth.dto.response.TokenResponse;
+import com.sparta.taskflow.auth.service.AuthService;
 import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
 import com.sparta.taskflow.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -25,6 +27,17 @@ public class AuthController {
         UserResponseDto responseDto = authService.register(requestDto);
 
         ApiResponse<UserResponseDto> response = ApiResponse.success("회원가입이 완료되었습니다.", responseDto);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(
+        @Valid @RequestBody LoginRequestDto requestDto) {
+        TokenResponse responseDto = authService.login(requestDto.getUsername(),
+            requestDto.getPassword());
+
+        ApiResponse<TokenResponse> response = ApiResponse.success("로그인이 완료되었습니다.", responseDto);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/sparta/taskflow/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/sparta/taskflow/auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.taskflow.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+
+    @NotNull
+    private String username;
+
+    @NotNull
+    private String password;
+}

--- a/src/main/java/com/sparta/taskflow/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/sparta/taskflow/auth/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.sparta.taskflow.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TokenResponse {
+
+    private String token;
+}

--- a/src/main/java/com/sparta/taskflow/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sparta/taskflow/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.sparta.taskflow.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.taskflow.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/***
+ * Spring Security의 AuthorizationFilter와 협력하여
+ * 미인증 사용자에게 401 Unauthorized로 응답한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+
+        ApiResponse apiResponse = ApiResponse.fail("인증이 필요합니다", null);
+
+        response.setStatus(401);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+
+}

--- a/src/main/java/com/sparta/taskflow/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sparta/taskflow/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -27,7 +27,12 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException) throws IOException, ServletException {
 
-        ApiResponse apiResponse = ApiResponse.fail("인증이 필요합니다", null);
+        String errorMessage = (String) request.getAttribute("jwt.message");
+        if(errorMessage == null) {
+            errorMessage = "인증이 필요합니다.";
+        }
+
+        ApiResponse apiResponse = ApiResponse.fail(errorMessage, null);
 
         response.setStatus(401);
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/sparta/taskflow/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/sparta/taskflow/auth/jwt/JwtFilter.java
@@ -1,0 +1,57 @@
+package com.sparta.taskflow.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 토큰이 존재하는 경우에 올바른 토큰인지만 검증하는 필터이다.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        /*
+         토큰이 없거나 잘못된 토큰일 때 다음 FilterChain으로 넘기면
+         Spring Security의 AnonymousAuthenticationFilter가
+         미인증 상태를 나타내는 Authentication인 AnonymousAuthenticationToken을 SecurityContext에 넣어준다.
+         그리고 이는 이후 인가 필터에서 자동으로 걸러지므로 토큰이 없는 경우 추가 작업이 필요하지 않다.
+         */
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String jwt = jwtUtil.getTokenFromRequest(request);
+        boolean isTokenInvalid = !jwtUtil.validateToken(jwt);
+        if (isTokenInvalid) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String id = jwtUtil.extractUserIdFromToken(jwt);
+        String role = jwtUtil.extractUserRoleFromToken(jwt);
+        User user = new User(id, "", List.of(new SimpleGrantedAuthority(role)));
+
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities()));
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sparta/taskflow/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/sparta/taskflow/auth/jwt/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.sparta.taskflow.auth.jwt;
 
+import com.sparta.taskflow.global.exception.JwtAuthenticationException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,13 +36,18 @@ public class JwtFilter extends OncePerRequestFilter {
          */
         String authorizationHeader = request.getHeader("Authorization");
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            request.setAttribute("jwt.exception", "TOKEN_NOT_PROVIDED");
+            request.setAttribute("jwt.message", "JWT 토큰이 없습니다.");
             filterChain.doFilter(request, response);
             return;
         }
 
         String jwt = jwtUtil.getTokenFromRequest(request);
-        boolean isTokenInvalid = !jwtUtil.validateToken(jwt);
-        if (isTokenInvalid) {
+        try {
+            jwtUtil.validateToken(jwt);
+        } catch (JwtAuthenticationException e) {
+            request.setAttribute("jwt.exception", e.getErrorCode());
+            request.setAttribute("jwt.message", e.getMessage());
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/sparta/taskflow/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/sparta/taskflow/auth/jwt/JwtFilter.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * 토큰이 존재하는 경우에 올바른 토큰인지만 검증하는 필터이다.
+ * 토큰이 존재하는 경우에 userId를 Spring Security User 타입에 담아 SecurityContext에 넣어준다.
+ * 토큰이 존재하지 않거나 유효하지 않은 토큰인 경우 오류 메시지를 request attribute에 담아
+ * JwtAuthenticationEntryPoint에서 사용할 수 있도록 한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -32,7 +34,7 @@ public class JwtFilter extends OncePerRequestFilter {
          토큰이 없거나 잘못된 토큰일 때 다음 FilterChain으로 넘기면
          Spring Security의 AnonymousAuthenticationFilter가
          미인증 상태를 나타내는 Authentication인 AnonymousAuthenticationToken을 SecurityContext에 넣어준다.
-         그리고 이는 이후 인가 필터에서 자동으로 걸러지므로 토큰이 없는 경우 추가 작업이 필요하지 않다.
+         이후 AuthorizationFilter에서 해당 Authentication은 미인증과 동일하게 처리된다.
          */
         String authorizationHeader = request.getHeader("Authorization");
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {

--- a/src/main/java/com/sparta/taskflow/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/taskflow/auth/jwt/JwtUtil.java
@@ -1,0 +1,86 @@
+package com.sparta.taskflow.auth.jwt;
+
+import com.sparta.taskflow.domain.user.type.RoleType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final static long TOKEN_TIME = 10 * 60 * 1000L; // 토큰 유효시간: 10분
+    private final static SignatureAlgorithm ALGORITHM = SignatureAlgorithm.HS256;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+
+    // 토큰 초기화
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Long userId, RoleType roleType) {
+        Date date = new Date();
+
+        return Jwts.builder().setSubject(userId.toString())
+                   .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                   .setIssuedAt(date)
+                   .claim("role", roleType.getValue())
+                   .signWith(key, ALGORITHM).compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {       // 토큰이 만료된 경우
+            log.error("만료된 토큰입니다.", e);
+        } catch (SignatureException e) {        // 토큰 서명이 잘못된 경우
+            log.error("서명이 유효하지 않은 토큰입니다.", e);
+        } catch (MalformedJwtException | UnsupportedJwtException |
+                 SecurityException e) {     // 잘못된 형식의 토큰이 전달된 경우
+            log.error("잘못된 형식의 토큰입니다.", e);
+        } catch (IllegalArgumentException e) {  // 토큰이 없는 경우
+            log.error("잘못된 토큰입니다.", e);
+        }
+
+        return false;
+    }
+
+    public String getTokenFromRequest(HttpServletRequest request) {
+        return request.getHeader("Authorization").substring(7);
+    }
+
+    public String extractUserIdFromToken(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public String extractUserRoleFromToken(String token) {
+        return (String) parseClaims(token).get("role");
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key)           // 서명 검증을 위한 키
+                   .build().parseClaimsJws(token)        // 유효성 검사 및 파싱
+                   .getBody();
+    }
+}

--- a/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
@@ -9,7 +9,6 @@ import com.sparta.taskflow.domain.user.repository.UserRepository;
 import com.sparta.taskflow.domain.user.type.RoleType;
 import com.sparta.taskflow.global.exception.CustomException;
 import com.sparta.taskflow.global.exception.ErrorCode;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -38,7 +37,7 @@ public class AuthService {
 
     public TokenResponse login(String username, String password) {
         // 사용자를 찾을 수 없는 경우에도 자세한 이유는 숨김
-        User foundUser = userRepository.findByUsername(username).orElseThrow(
+        User foundUser = userRepository.findByUsernameAndIsDeletedFalse(username).orElseThrow(
             () -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
 
         if (!passwordEncoder.matches(password, foundUser.getPassword())) {

--- a/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
@@ -1,12 +1,15 @@
 package com.sparta.taskflow.auth.service;
 
 import com.sparta.taskflow.auth.dto.request.RegisterRequestDto;
+import com.sparta.taskflow.auth.dto.response.TokenResponse;
+import com.sparta.taskflow.auth.jwt.JwtUtil;
 import com.sparta.taskflow.domain.user.dto.response.UserResponseDto;
 import com.sparta.taskflow.domain.user.entity.User;
 import com.sparta.taskflow.domain.user.repository.UserRepository;
 import com.sparta.taskflow.domain.user.type.RoleType;
 import com.sparta.taskflow.global.exception.CustomException;
 import com.sparta.taskflow.global.exception.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
 
     public UserResponseDto register(RegisterRequestDto requestDto) {
@@ -30,6 +34,19 @@ public class AuthService {
         User savedUser = userRepository.save(user);
 
         return UserResponseDto.of(savedUser);
+    }
+
+    public TokenResponse login(String username, String password) {
+        // 사용자를 찾을 수 없는 경우에도 자세한 이유는 숨김
+        User foundUser = userRepository.findByUsername(username).orElseThrow(
+            () -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(password, foundUser.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String token = jwtUtil.createToken(foundUser.getId(), foundUser.getRole());
+        return new TokenResponse(token);
     }
 
     private void checkDuplicatesOrThrow(String username, String email) {

--- a/src/main/java/com/sparta/taskflow/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/entity/User.java
@@ -27,6 +27,8 @@ public class User extends BaseTimeEntity {
 
     @Column(unique = true)
     private String username;
+
+    @Column(unique = true)
     private String email;
     private String password;
     private String name;

--- a/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
@@ -10,5 +10,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
-    Optional<User> findByUsername(String username);
+    Optional<User> findByUsernameAndIsDeletedFalse(String username);
 }

--- a/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.taskflow.domain.user.repository;
 
 import com.sparta.taskflow.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -9,4 +10,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.sparta.taskflow.global.config;
 
+import com.sparta.taskflow.auth.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.taskflow.auth.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,17 +11,27 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable).formLogin(AbstractHttpConfigurer::disable)
+            .exceptionHandling(ex -> {
+                ex.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+            })
             .authorizeHttpRequests(auth -> {
-                auth.requestMatchers("/**").permitAll(); // 아직 인증 안 함
-            });
+                auth.requestMatchers("/api/auth/login", "api/auth/register").permitAll()
+                    .anyRequest().authenticated();
+            })
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
@@ -28,8 +28,10 @@ public class SecurityConfig {
                 ex.authenticationEntryPoint(jwtAuthenticationEntryPoint);
             })
             .authorizeHttpRequests(auth -> {
-                auth.requestMatchers("/api/auth/login", "api/auth/register").permitAll()
-                    .anyRequest().authenticated();
+                auth
+//                    .requestMatchers("/api/auth/login", "api/auth/register").permitAll()
+//                    .anyRequest().authenticated()
+                    .anyRequest().permitAll(); // Todo: 개발 환경에서 인증 사용 x, 실제 동작 시 위 주석 해제
             })
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
     // User 관련 에러 정의
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자명입니다."),
-    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+
+    // 인증 관련 에러
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 사용자명 또는 비밀번호입니다.");
 
     // 필드
     // HTTP 상태코드

--- a/src/main/java/com/sparta/taskflow/global/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/JwtAuthenticationException.java
@@ -1,0 +1,4 @@
+package com.sparta.taskflow.global.exception;
+
+public class JwtAuthenticationException {
+}

--- a/src/main/java/com/sparta/taskflow/global/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/JwtAuthenticationException.java
@@ -1,4 +1,15 @@
 package com.sparta.taskflow.global.exception;
 
-public class JwtAuthenticationException {
+import lombok.Getter;
+
+@Getter
+public class JwtAuthenticationException extends RuntimeException {
+
+    private final String errorCode;
+
+    public JwtAuthenticationException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,10 @@ spring:
         # 컨트롤러나 뷰에서 DB에 영향을 주는 것은 차단하기 위해 영속성 컨테스트를 서비스 계층에서 닫음
         open-in-view: false
 
+jwt:
+  secret:
+    key: ${SECRET_KEY}
+
 servlet:
   multipart:
     # 파일 업로드 최대 크기

--- a/src/test/java/com/sparta/taskflow/auth/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/sparta/taskflow/auth/AuthenticationIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.sparta.taskflow.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.taskflow.auth.dto.request.LoginRequestDto;
+import com.sparta.taskflow.domain.user.entity.User;
+import com.sparta.taskflow.domain.user.repository.UserRepository;
+import com.sparta.taskflow.domain.user.type.RoleType;
+import com.sparta.taskflow.response.ApiResponse;
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+// 테스트가 제대로 동작하려면 SecurityConfig.java 파일에서 경로 주석을 해제해주어야 한다.
+public class AuthenticationIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository; // 그냥 엔티티로 만들어서 직접 넣어주는 것은 비추?
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void 인증되지_않은_사용자_일반페이지_접근불가() throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.get("/not-existing-page")
+        );
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
+    /*
+    Fixme
+     원래 Spring MVC가 예외를 만들고 그걸 잡아 404 응답을 내보내줘야 하나
+     GlobalExceptionHandler가 최상위 클래스인 Exception을 받아서 다 500으로 반환됨
+    */
+    @Test
+    void 로그인_후_없는_페이지_접근_시_404() throws Exception {
+        // given
+        saveUser("username", "password");
+
+        ResultActions resultActions = login("username", "password");
+        String token = getJwtFromResultActions(resultActions);
+
+        // when
+        ResultActions authenticatedAccessResultActions = mockMvc.perform(
+            MockMvcRequestBuilders.get("/not-existing-page")
+                                  .header("Authorization", "Bearer " + token)
+        );
+
+        // then
+        MvcResult authenticatedAccessMvcResult = authenticatedAccessResultActions.andReturn();
+        assertThat(authenticatedAccessMvcResult.getResponse().getStatus()).isEqualTo(500); // Fixme
+    }
+
+    private void saveUser(String username, String password) {
+        User user = User.builder()
+                        .username(username)
+                        .password(passwordEncoder.encode(password))
+                        .isDeleted(false)
+                        .role(RoleType.USER)
+                        .build();
+
+        userRepository.save(user);
+    }
+
+    private String getJwtFromResultActions(ResultActions resultActions)
+        throws UnsupportedEncodingException, JsonProcessingException {
+        MvcResult mvcResult = resultActions.andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String body = response.getContentAsString();
+
+        ApiResponse apiResponse = objectMapper.readValue(body, ApiResponse.class);
+        Map<String, String> map = (Map<String, String>) apiResponse.getData();
+        String token = map.get("token");
+
+        return token;
+    }
+
+    private ResultActions login(String username, String password) throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto();
+        ReflectionTestUtils.setField(loginRequest, "username", username);
+        ReflectionTestUtils.setField(loginRequest, "password", password);
+
+        return mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/auth/login")
+                                  .contentType(MediaType.APPLICATION_JSON)
+                                  .content(objectMapper.writeValueAsString(loginRequest))
+        );
+    }
+}

--- a/src/test/java/com/sparta/taskflow/auth/jwt/JwtFilterTest.java
+++ b/src/test/java/com/sparta/taskflow/auth/jwt/JwtFilterTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class JwtFilterTest {
+  
+}

--- a/src/test/java/com/sparta/taskflow/auth/jwt/JwtFilterTest.java
+++ b/src/test/java/com/sparta/taskflow/auth/jwt/JwtFilterTest.java
@@ -1,4 +1,102 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.sparta.taskflow.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import com.sparta.taskflow.domain.user.type.RoleType;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.security.Key;
+import java.util.Base64;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
 class JwtFilterTest {
-  
+
+    JwtUtil jwtUtil = new JwtUtil();
+    JwtFilter jwtFilter = new JwtFilter(jwtUtil); // JwtUtil과 강하게 결합되어 분리 어려움
+
+    @Mock
+    FilterChain filterChain;
+
+    @BeforeEach
+    void setKey() {
+        String secretKey = "slkdfjsdvhzxuocgvoawgwiufbdjkszvbkxsdfiusydv";
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        Key key = Keys.hmacShaKeyFor(bytes);
+        ReflectionTestUtils.setField(jwtUtil, "key", key);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 정상_토큰() throws ServletException, IOException {
+        // given
+        String token = jwtUtil.createToken(1L, RoleType.USER);
+
+        MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
+        httpServletRequest.addHeader("Authorization", "Bearer " + token);
+        willDoNothing().given(filterChain).doFilter(httpServletRequest, httpServletResponse);
+
+        // when
+        jwtFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
+
+        // then
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication.getPrincipal()).isInstanceOf(User.class);
+    }
+
+    @Test
+    void 잘못된_토큰() throws ServletException, IOException {
+        // given
+        MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
+        httpServletRequest.addHeader("Authorization", "Bearer INVALID_JWT");
+        willDoNothing().given(filterChain).doFilter(httpServletRequest, httpServletResponse);
+
+        // when
+        jwtFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
+
+        // then
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNull();
+
+        String message = (String) httpServletRequest.getAttribute("jwt.message");
+        assertThat(message).isEqualTo("잘못된 JWT 토큰입니다.");
+    }
+
+    @Test
+    void 토큰_미제공() throws ServletException, IOException {
+        // given
+        MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+        MockHttpServletResponse httpServletResponse = new MockHttpServletResponse();
+        willDoNothing().given(filterChain).doFilter(httpServletRequest, httpServletResponse);
+
+        // when
+        jwtFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
+
+        // then
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNull();
+
+        String message = (String) httpServletRequest.getAttribute("jwt.message");
+        assertThat(message).isEqualTo("JWT 토큰이 없습니다.");
+    }
 }


### PR DESCRIPTION
## 이슈 번호
#30 

## 작업 내용
- JWT 의존성, Mockito 의존성 추가
- 로그인 로직 구현
    - 정상 login 요청에 대해 토큰 응답
    - 비정상 login 요청에 대해 INVALID_CREDENTIALS 에러 코드 응답
- Spring Security 필터 체인 설정 추가 
- JwtFilter 추가
    - 토큰이 올바른 경우 SecurityContext에 id와 role 추가
    - 나머지는 모두 미인증 상태 유지하고, 예외 정보를 request attribute에 추가
- 토큰 생성, 검증, 정보 추출을 담당하는 JwtUtil 추가
- Spring Security 작업 흐름과 일관된 처리를 위해 JwtAuthenticationEntryPoint 설정, 토큰 관련 예외 정보가 있다면 포함하여 401 응답
- User 엔티티 email에 unique 제약 조건 추가
- JwtFilter 토큰 상태 별 단위 테스트 작성
- AuthService 통합 테스트에 로그인 관련 테스트 추가
- 미인증 사용자의 페이지 접근과 로그인 사용자의 페이지 접근 두 가지에 대한 통합 테스트 작성

## 스크린샷
### 정상 로그인
![image](https://github.com/user-attachments/assets/d69a0ee5-5549-4406-a69e-0e9f023d1b1f)

### 비밀번호 불일치
![image](https://github.com/user-attachments/assets/2efa20d4-41b4-4c43-916d-01ff43824d81)

### 미인증 접근
![image](https://github.com/user-attachments/assets/2cff69ed-e4d0-4106-9931-df052390d07c)


## 비고
- 머지 이후 정상 작동을 위해 환경 변수에 "SECRET_KEY" 값 설정 필요
- 통합 테스트를 실행하려면 프로필이 test인 application.yaml 파일을 생성하여 환경변수 값을 정의해야 하고, SecurityConfig의 주석도 해제해야 함