### PR TITLE
Fix/auth

### DIFF
--- a/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/taskflow/auth/controller/AuthController.java
@@ -14,6 +14,8 @@ import com.sparta.taskflow.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,7 +40,6 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenResponse>> login(
         @Valid @RequestBody LoginRequestDto requestDto) {
@@ -46,17 +47,17 @@ public class AuthController {
             requestDto.getPassword());
 
         ApiResponse<TokenResponse> response = ApiResponse.success("로그인이 완료되었습니다.", responseDto);
+        return ResponseEntity.ok(response);
+    }
 
-
-    // TODO : SpringSecurity 적용 이후 로그인 유저 정보 받는 방법으로 변경 필요.
     @PostMapping("/withdraw")
     public ResponseEntity<ApiResponse<Void>> withdraw(
-        @RequestParam Long loginUserId,
+        @AuthenticationPrincipal User user,
         @RequestBody @Valid DeleteUserRequestDto deleteUserDto
     ) {
+        Long loginUserId = Long.valueOf(user.getUsername());
         userService.deleteUser(loginUserId, deleteUserDto);
         ApiResponse<Void> response = ApiResponse.success("회원탈퇴가 완료되었습니다.", null);
-
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/taskflow/auth/service/AuthService.java
@@ -12,14 +12,17 @@ import com.sparta.taskflow.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AuthService {
 
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
+
 
     public UserResponseDto register(RegisterRequestDto requestDto) {
         checkDuplicatesOrThrow(requestDto.getUsername(), requestDto.getEmail());
@@ -35,6 +38,7 @@ public class AuthService {
         return UserResponseDto.of(savedUser);
     }
 
+    @Transactional(readOnly = true)
     public TokenResponse login(String username, String password) {
         // 사용자를 찾을 수 없는 경우에도 자세한 이유는 숨김
         User foundUser = userRepository.findByUsernameAndIsDeletedFalse(username).orElseThrow(

--- a/src/main/java/com/sparta/taskflow/domain/activitylog/aop/ActivityLogAspect.java
+++ b/src/main/java/com/sparta/taskflow/domain/activitylog/aop/ActivityLogAspect.java
@@ -3,7 +3,7 @@ package com.sparta.taskflow.domain.activitylog.aop;
 import com.sparta.taskflow.domain.activitylog.Enum.ActivityType;
 import com.sparta.taskflow.domain.activitylog.entity.ActivityLog;
 import com.sparta.taskflow.domain.activitylog.repository.ActivityLogRepository;
-import com.sparta.taskflow.domain.comment.dto.CreateCommentResponseDto;
+import com.sparta.taskflow.domain.comment.dto.CommentResponseDto;
 import com.sparta.taskflow.domain.task.dto.response.TaskResponseDto;
 import com.sparta.taskflow.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -116,8 +116,8 @@ public class ActivityLogAspect {
             return dto.getId();
         }
 
-        if (data instanceof CreateCommentResponseDto && activityType.name().startsWith("COMMENT_")) {
-            CreateCommentResponseDto dto = (CreateCommentResponseDto) data;
+        if (data instanceof CommentResponseDto && activityType.name().startsWith("COMMENT_")) {
+            CommentResponseDto dto = (CommentResponseDto) data;
             return dto.getId();
         }
 

--- a/src/main/java/com/sparta/taskflow/domain/activitylog/dto/ActivityLogResponseDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/activitylog/dto/ActivityLogResponseDto.java
@@ -4,12 +4,14 @@ import com.sparta.taskflow.domain.activitylog.Enum.ActivityType;
 import com.sparta.taskflow.domain.activitylog.entity.ActivityLog;
 
 import java.time.LocalDateTime;
+import lombok.Getter;
 
+@Getter
 public class ActivityLogResponseDto {
 
     private Long id;
     private Long userId;
-    private ActivityType activityType;
+    private String activityType;
     private Long targetId;
     private String method;
     private String url;
@@ -20,7 +22,7 @@ public class ActivityLogResponseDto {
     public ActivityLogResponseDto(ActivityLog log) {
         this.id = log.getId();
         this.userId = log.getUserId();
-        this.activityType = log.getActivityType();
+        this.activityType = log.getActivityType().toString();
         this.targetId = log.getTargetId();
         this.method = log.getMethod();
         this.url = log.getUrl();

--- a/src/main/java/com/sparta/taskflow/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/controller/UserController.java
@@ -7,6 +7,8 @@ import com.sparta.taskflow.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,10 +23,10 @@ public class UserController {
 
     private final UserService userService;
 
-    // TODO : SpringSecurity 적용 이후 로그인 유저 정보 받는 방법으로 변경 필요.
-    // TODO : 조회 시 isDeleted = false인 유저만 조회하도록 변경
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponseDto>> getUserByLoginUser(@RequestParam Long loginUserId) {
+    public ResponseEntity<ApiResponse<UserResponseDto>> getUserByLoginUser(@AuthenticationPrincipal
+    User user) {
+        Long loginUserId = Long.valueOf(user.getUsername());
         UserResponseDto response = userService.getUser(loginUserId);
         return ResponseEntity.ok(ApiResponse.success("사용자 정보를 조회했습니다.", response));
     }

--- a/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/repository/UserRepository.java
@@ -16,7 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
   
     Optional<User> findByIdAndIsDeletedFalse(Long id);
 
-    default User findByIdOrElseThrow(Long loginUserId) {
-        return findById(loginUserId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    default User findByIdAndIsDeletedFalseOrElseThrow(Long loginUserId) {
+        return findByIdAndIsDeletedFalse(loginUserId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/sparta/taskflow/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     private final PasswordValidator passwordValidator;
 
     public UserResponseDto getUser(Long loginUserId) {
-        User foundUser = userRepository.findByIdOrElseThrow(loginUserId);
+        User foundUser = userRepository.findByIdAndIsDeletedFalseOrElseThrow(loginUserId);
         return UserResponseDto.of(foundUser);
     }
 

--- a/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/taskflow/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.sparta.taskflow.auth.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -23,7 +24,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable).formLogin(AbstractHttpConfigurer::disable)
+        http.csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .cors(Customizer.withDefaults())
             .exceptionHandling(ex -> {
                 ex.authenticationEntryPoint(jwtAuthenticationEntryPoint);
             })

--- a/src/main/java/com/sparta/taskflow/global/config/WebConfig.java
+++ b/src/main/java/com/sparta/taskflow/global/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.sparta.taskflow.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3100")
+                .allowedMethods("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 3100 CORS 허용 설정
- ActivityLogResponseDto에 Getter 추가
- @AuthenticationPrincipal로 사용자 인증 정보 조회
- AuthService 메소드에 트랜잭션 경계 설정
- User가 isDeleted가 false인 경우에만 조회되도록 변경