### PR TITLE
feat: 댓글 삭제 기능 구현 (Soft Delete)

### DIFF
--- a/src/main/java/com/sparta/taskflow/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/controller/CommentController.java
@@ -47,6 +47,7 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
+    // 댓글 검색
     @GetMapping("/comments/search")
     public ResponseEntity<ApiResponse<Page<CommentResponseDto>>> searchComments(
         @RequestParam String keyword,
@@ -54,5 +55,15 @@ public class CommentController {
     ) {
         Page<CommentResponseDto> result = commentService.searchComments(keyword, pageable);
         return ResponseEntity.ok(ApiResponse.success("댓글 검색 결과입니다.", result));
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+        @PathVariable Long taskId,
+        @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(taskId, commentId);
+        return ResponseEntity.ok(ApiResponse.success("댓글이 삭제되었습니다.", null));
     }
 }

--- a/src/main/java/com/sparta/taskflow/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/dto/CommentRequestDto.java
@@ -1,5 +1,6 @@
 package com.sparta.taskflow.domain.comment.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,7 +8,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CommentRequestDto {
 
+    @NotNull(message = "내용은 필수입니다.")
     private String content;
+
+    @NotNull(message = "유저ID는 필수입니다.")
     private Long userId;
 
     public CommentRequestDto(String content, Long userId) {

--- a/src/main/java/com/sparta/taskflow/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.taskflow.domain.comment.repository;
 
 import com.sparta.taskflow.domain.comment.entity.Comment;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findByContentContainingIgnoreCaseAndIsDeletedFalseOrderByCreatedAtDesc(
         String keyword, Pageable pageable);
+
+    Optional<Comment> findByIdAndTaskIdAndIsDeletedFalse(Long id, Long taskId);
 }

--- a/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
@@ -70,11 +70,17 @@ public class CommentService {
     // 댓글 삭제
     public void deleteComment(Long commentId, Long taskId) {
         Comment comment = commentRepository.findByIdAndTaskIdAndIsDeletedFalse(commentId, taskId)
-            .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+                                           .orElseThrow(() -> new CustomException(
+                                               ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getIsDeleted()) {
+            throw new CustomException(ErrorCode.COMMENT_ALREADY_DELETED);
+        }
 
         if (!comment.getTaskId().equals(taskId)) {
             throw new CustomException(ErrorCode.COMMENT_TASK_MISMATCH);
         }
+
         comment.softDelete();
         commentRepository.save(comment);
     }

--- a/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/taskflow/domain/comment/service/CommentService.java
@@ -66,4 +66,16 @@ public class CommentService {
             return CommentResponseDto.of(comment, userDto);
         });
     }
+
+    // 댓글 삭제
+    public void deleteComment(Long commentId, Long taskId) {
+        Comment comment = commentRepository.findByIdAndTaskIdAndIsDeletedFalse(commentId, taskId)
+            .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getTaskId().equals(taskId)) {
+            throw new CustomException(ErrorCode.COMMENT_TASK_MISMATCH);
+        }
+        comment.softDelete();
+        commentRepository.save(comment);
+    }
 }

--- a/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
     // Comment 관련 에러
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+    COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 댓글입니다."),
     COMMENT_TASK_MISMATCH(HttpStatus.BAD_REQUEST, "해당 댓글은 지정된 태스크에 속하지 않습니다.");
 
     // 필드

--- a/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/taskflow/global/exception/ErrorCode.java
@@ -28,7 +28,11 @@ public enum ErrorCode {
     // Task 관련 에러 정의
     ASSIGNEE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않거나 탈퇴된 담당자입니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "잘못된 상태 변경입니다."),
-    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 작업을 찾을 수 없습니다.");
+    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 작업을 찾을 수 없습니다."),
+
+    // Comment 관련 에러
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+    COMMENT_TASK_MISMATCH(HttpStatus.BAD_REQUEST, "해당 댓글은 지정된 태스크에 속하지 않습니다.");
 
     // 필드
     // HTTP 상태코드


### PR DESCRIPTION
## 이슈 번호
#39

## 작업 내용
- Comment 엔티티에 softDelete() 메서드 추가
- CommentService에 댓글 삭제 비즈니스 로직 구현
- CommentController에 DELETE /api/tasks/{taskId}/comments/{commentId} API 추가
- 삭제된 댓글은 조회되지 않도록 Repository 쿼리 필터 적용 (`isDeleted = false`)
- 삭제 성공 시 메시지만 반환 (`ApiResponse.success`)

## 스크린샷(선택)
